### PR TITLE
Add D203 to pep257 ignore list.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202,D211
+  - pep257 . --ignore=D202,D203

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --ignore=D202,D211

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,6 @@ from SublimeLinter.lint import Linter, util
 
 
 class Julialint(Linter):
-
     """Provides an interface to julialint."""
 
     syntax = 'julia'


### PR DESCRIPTION
D211 and D203 are in conflict according to [this issue](https://github.com/PyCQA/pydocstyle/issues/141) and according to [their definitions in the linter code](http://www.pydocstyle.org/en/latest/error_codes.html#grouping).

According to the issue mentioned above, D203 should be ignored to comply with Guido's intent in [this pep change](https://hg.python.org/peps/rev/9b715d8246db). This fixed builds for me ([source](https://travis-ci.org/distortedsignal/SublimeLinter-contrib-julialint)). I think this is the best way forward.